### PR TITLE
fix: omit npm outdated error from stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ COPY . .
 
 RUN npm install
 
+ENV NPM_CONFIG_UPDATE_NOTIFIER="false"
+
 CMD [ "npm", "start", "--silent" ]


### PR DESCRIPTION
The keboola integration reads data from stdout of container. 
If there is npm outdated message, it is printed into UI.
![Screenshot 2023-06-05 at 16 57 39](https://github.com/apify/keboola-ex-apify/assets/11837643/cb565905-9cd3-45f2-8072-b11b36971e2a)

This should fix this by omitiing an outdated error.